### PR TITLE
ci: skip SonarCloud until SONAR_ORGANIZATION is set

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -74,8 +74,14 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  # SonarQube Cloud Free: main only. Skip until the owner sets
+  # repository variable SONAR_ORGANIZATION (token alone is not enough;
+  # empty org + invalid/legacy token returns HTTP 403 from api.sonarcloud.io).
   sonar:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      vars.SONAR_ORGANIZATION != ''
     runs-on: ubuntu-latest
     needs: quality
     steps:
@@ -98,6 +104,10 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
         run: |
+          if [ -z "$SONAR_TOKEN" ]; then
+            echo "SONAR_TOKEN is empty; skip SonarCloud upload."
+            exit 0
+          fi
           ./mvnw -B sonar:sonar \
             -Dsonar.projectKey=vaultspring \
             -Dsonar.organization="$SONAR_ORGANIZATION" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project uses [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- CI `sonar` job no longer fails `main` when `SONAR_ORGANIZATION` is unset (HTTP 403 from SonarCloud)
+
 ### Added
 
 - Cursor / Copilot agent layer: `AGENTS.md`, `.cursor/rules/`, `.github/agents/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Optional coverage:
 - Maven `verify` + JaCoCo
 - Codecov upload (non-blocking)
 - CodeQL (`github/codeql-action@v4`)
-- SonarQube Cloud on **push to `main`** (Free plan: main branch only)
+- SonarQube Cloud on **push to `main`** only when repository variable `SONAR_ORGANIZATION` is set (Free plan: main branch). Until then the job is skipped so CI stays green. Also requires secret `SONAR_TOKEN` (SonarCloud, not a local SonarQube token).
 
 ### GitHub settings (owner)
 


### PR DESCRIPTION
## Summary
- Push para `main` ficou vermelho: job `sonar` 403 (`SONAR_ORGANIZATION` vazio; token não autentica no SonarCloud).
- Quality e CodeQL já estavam verdes. O job Sonar só corre quando a variável do repositório existe.

Closes nothing — unblocks `main` CI.

## Test plan
- [ ] PR checks: quality + codeql verdes; sonar skipped
- [ ] Após merge, workflow em `main` success (sonar skipped)


Made with [Cursor](https://cursor.com)