### PR TITLE
ci: apontar SonarCloud para KleilsonSantos_VaultSpring

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -109,7 +109,7 @@ jobs:
             exit 0
           fi
           ./mvnw -B sonar:sonar \
-            -Dsonar.projectKey=vaultspring \
+            -Dsonar.projectKey=KleilsonSantos_VaultSpring \
             -Dsonar.organization="$SONAR_ORGANIZATION" \
             -Dsonar.host.url=https://sonarcloud.io \
             -Dsonar.token="$SONAR_TOKEN" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project uses [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - CI `sonar` job no longer fails `main` when `SONAR_ORGANIZATION` is unset (HTTP 403 from SonarCloud)
+- SonarCloud `projectKey` set to `KleilsonSantos_VaultSpring` (org `kleilsonsantos`)
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Optional coverage:
 - Maven `verify` + JaCoCo
 - Codecov upload (non-blocking)
 - CodeQL (`github/codeql-action@v4`)
-- SonarQube Cloud on **push to `main`** only when repository variable `SONAR_ORGANIZATION` is set (Free plan: main branch). Until then the job is skipped so CI stays green. Also requires secret `SONAR_TOKEN` (SonarCloud, not a local SonarQube token).
+- SonarQube Cloud on **push to `main`** when `SONAR_ORGANIZATION` is set. Project key: `KleilsonSantos_VaultSpring`. Requires secret `SONAR_TOKEN` from [SonarCloud Access Tokens](https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens) (not the local SonarQube on `:9000`).
 
 ### GitHub settings (owner)
 


### PR DESCRIPTION
## Summary
- Org e token já estão no GitHub (`SONAR_ORGANIZATION=kleilsonsantos`, secret `SONAR_TOKEN`).
- O `projectKey` do job passa a ser `KleilsonSantos_VaultSpring`, a key real no SonarCloud.

## Test plan
- [ ] Após merge em `main`, job `sonar` roda (não skipped) e termina success
- [ ] Dashboard: https://sonarcloud.io/project/overview?id=KleilsonSantos_VaultSpring


Made with [Cursor](https://cursor.com)