### PR TITLE
fix: Render datasource env + Dependabot Boot major guard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,10 @@ updates:
       spring-boot:
         patterns:
           - "org.springframework.boot*"
-          - "org.springframework*"
+    ignore:
+      # Boot 4.x is a dedicated epic (#33), not a Dependabot drive-by
+      - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project uses [Semantic Versioning](https://semver.org/).
 
 - CI `sonar` job no longer fails `main` when `SONAR_ORGANIZATION` is unset (HTTP 403 from SonarCloud)
 - SonarCloud `projectKey` set to `KleilsonSantos_VaultSpring` (org `kleilsonsantos`)
+- Render blueprint uses `SPRING_DATASOURCE_*` and `/actuator/health` (aligned with `application-prod.yml`)
 
 ### Added
 
@@ -31,6 +32,7 @@ and this project uses [Semantic Versioning](https://semver.org/).
 - `application.yml` no longer forces `prod`; default profile is `dev`. Production credentials come from the environment
 - Dockerfile copies `target/app.jar` (matches `<finalName>app</finalName>`)
 - README/HELP describe the stack that actually exists in `pom.xml`
+- Dependabot ignores semver-major bumps on `spring-boot-starter-parent` (Boot 4 tracked in #33)
 
 ### Fixed
 

--- a/render.yml
+++ b/render.yml
@@ -1,22 +1,17 @@
+# Render Blueprint — https://render.com/docs/blueprint-spec
+# Set SPRING_DATASOURCE_* in the Render dashboard (sync: false). Do not commit credentials.
 services:
   - type: web
     name: vaultspring
     env: docker
     dockerfilePath: Dockerfile
-    startCommand: java -jar app.jar
+    healthCheckPath: /actuator/health
     envVars:
       - key: SPRING_PROFILES_ACTIVE
         value: prod
-      - key: DB_URL
-        value: jdbc:postgresql://<HOST>:5432/<DATABASE>
-      - key: DB_USER
-        value: admin
-      - key: DB_PASS
-        value: adminpass
-      - key: SECURITY_USER_NAME
-        value: admin
-      - key: SECURITY_USER_PASSWORD
-        value: adminpass
-      - key: SECURITY_USER_ROLES
-        value: USER
-
+      - key: SPRING_DATASOURCE_URL
+        sync: false
+      - key: SPRING_DATASOURCE_USERNAME
+        sync: false
+      - key: SPRING_DATASOURCE_PASSWORD
+        sync: false


### PR DESCRIPTION
## Summary
- **Render:** `render.yml` uses `SPRING_DATASOURCE_*` (not legacy `DB_*`), health check on `/actuator/health`, secrets via dashboard (`sync: false`).
- **Dependabot:** ignore semver-major on `spring-boot-starter-parent` — Boot 4 stays in #33, not auto-PR.

## Test plan
- [ ] After merge, configure `SPRING_DATASOURCE_*` in Render dashboard and redeploy
- [ ] Close Dependabot #39 (superseded by this policy)


Made with [Cursor](https://cursor.com)