### PR TITLE
ci: uma só via SonarCloud (Automatic Analysis)

### DIFF
--- a/.cursor/rules/quality-gates.mdc
+++ b/.cursor/rules/quality-gates.mdc
@@ -17,12 +17,12 @@ Sources of truth:
 - Local: `./mvnw -B checkstyle:check test` before push when Java/XML changes
 - CI quality job must pass before merge
 - CodeQL uses `github/codeql-action@v4` (v3 is deprecated)
-- SonarQube Cloud Free: scan on **push to `main` only** — not every PR
+- SonarQube Cloud: **GitHub Automatic Analysis** only — do not add a Maven `sonar:sonar` job while Automatic Analysis is on (SonarCloud rejects duplicate CI analysis). PR check: `SonarCloud Code Analysis`.
 - Maven cache: `actions/setup-java` `cache: maven` only — do not add a second `actions/cache` for `~/.m2`
 - Codecov must not fail the build (`fail_ci_if_error: false`) unless the owner changes that
 
 ## SonarQube Cloud (Free)
 
-Official limits: main-branch analysis; PR analysis targeting `main` may be unavailable on Free. Keep the `sonar` job on `push` to `main`.
+Use the GitHub integration (Automatic Analysis). Dashboard: `KleilsonSantos_VaultSpring` on sonarcloud.io. JaCoCo coverage stays in Codecov unless Automatic Analysis is disabled and CI analysis is configured instead.
 
 Refs: [SonarQube Cloud subscription plans](https://docs.sonarsource.com/sonarqube-cloud/administering-sonarcloud/managing-subscription/subscription-plans)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -74,47 +74,6 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  # SonarQube Cloud Free: main only. Skip until the owner sets
-  # repository variable SONAR_ORGANIZATION (token alone is not enough;
-  # empty org + invalid/legacy token returns HTTP 403 from api.sonarcloud.io).
-  sonar:
-    if: >-
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/main' &&
-      vars.SONAR_ORGANIZATION != ''
-    runs-on: ubuntu-latest
-    needs: quality
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: "17"
-          cache: maven
-
-      - name: Tests + coverage for Sonar
-        run: ./mvnw -B verify --no-transfer-progress
-
-      - name: SonarQube Cloud
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_ORGANIZATION: ${{ vars.SONAR_ORGANIZATION }}
-        run: |
-          if [ -z "$SONAR_TOKEN" ]; then
-            echo "SONAR_TOKEN is empty; skip SonarCloud upload."
-            exit 0
-          fi
-          ./mvnw -B sonar:sonar \
-            -Dsonar.projectKey=KleilsonSantos_VaultSpring \
-            -Dsonar.organization="$SONAR_ORGANIZATION" \
-            -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.token="$SONAR_TOKEN" \
-            -Dsonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
-
   codeql:
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project uses [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - CI `sonar` job no longer fails `main` when `SONAR_ORGANIZATION` is unset (HTTP 403 from SonarCloud)
-- SonarCloud `projectKey` set to `KleilsonSantos_VaultSpring` (org `kleilsonsantos`)
+- Removed duplicate Maven Sonar job that conflicted with SonarCloud Automatic Analysis
 - Render blueprint uses `SPRING_DATASOURCE_*` and `/actuator/health` (aligned with `application-prod.yml`)
 
 ### Added
@@ -28,7 +28,7 @@ and this project uses [Semantic Versioning](https://semver.org/).
 
 - Spring Boot parent **3.5.16** (last OSS 3.5 patch). Flyway and PostgreSQL versions come from the Boot BOM; added `flyway-database-postgresql`
 - CI uses `actions/checkout@v5`, `setup-java` Maven cache only (no duplicate `actions/cache`), Codecov v5, `./mvnw`
-- SonarQube Cloud job runs on **push to `main`** (Free-plan branch limit). Set repository variable `SONAR_ORGANIZATION` and secret `SONAR_TOKEN`
+- SonarQube Cloud via GitHub Automatic Analysis (not a duplicate Maven `sonar` job)
 - `application.yml` no longer forces `prod`; default profile is `dev`. Production credentials come from the environment
 - Dockerfile copies `target/app.jar` (matches `<finalName>app</finalName>`)
 - README/HELP describe the stack that actually exists in `pom.xml`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ Optional coverage:
 - Maven `verify` + JaCoCo
 - Codecov upload (non-blocking)
 - CodeQL (`github/codeql-action@v4`)
-- SonarQube Cloud on **push to `main`** when `SONAR_ORGANIZATION` is set. Project key: `KleilsonSantos_VaultSpring`. Requires secret `SONAR_TOKEN` from [SonarCloud Access Tokens](https://docs.sonarsource.com/sonarqube-cloud/managing-your-account/managing-tokens) (not the local SonarQube on `:9000`).
+- SonarQube Cloud via **GitHub integration** (Automatic Analysis) — check `SonarCloud Code Analysis` on PRs; dashboard: [KleilsonSantos_VaultSpring](https://sonarcloud.io/project/overview?id=KleilsonSantos_VaultSpring). Do not run a Maven `sonar:sonar` job while Automatic Analysis is enabled (SonarCloud rejects duplicate CI analysis).
+- Codecov for JaCoCo coverage in CI
 
 ### GitHub settings (owner)
 


### PR DESCRIPTION
## Summary
- Remove job Maven `sonar:sonar` — conflitava com Automatic Analysis já ativo no projeto [KleilsonSantos_VaultSpring](https://sonarcloud.io/project/overview?id=KleilsonSantos_VaultSpring).
- Mantém `SonarCloud Code Analysis` nos PRs + Codecov para cobertura JaCoCo.

## Test plan
- [ ] PR checks verdes (quality + codeql + SonarCloud decoration)
- [ ] Push em `main` sem job sonar vermelho


Made with [Cursor](https://cursor.com)