### PR TITLE
ci: remove Actions Node 20 and CodeQL manual build warnings

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -40,14 +40,14 @@ jobs:
 
       - name: Upload JaCoCo report
         if: success() && !env.ACT && hashFiles('target/site/jacoco/jacoco.xml') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: jacoco-report
           path: target/site/jacoco/
 
       - name: Upload application JAR
         if: success() && !env.ACT && hashFiles('target/app.jar') != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: app-build
           path: target/app.jar
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "17"
@@ -93,10 +93,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
-          build-mode: manual
-
-      - name: Build for CodeQL
-        run: ./mvnw -B -DskipTests compile --no-transfer-progress
+          build-mode: none
 
       - name: Analyze
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Codecov
         if: success() && !env.ACT && hashFiles('target/site/jacoco/jacoco.xml') != ''
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: target/site/jacoco/jacoco.xml
           flags: unittests


### PR DESCRIPTION
## Summary
- Upgrade `actions/setup-java@v4` → `@v5` (Node 24 runtime)
- Upgrade `actions/upload-artifact@v4` → `@v6` (Node 24 runtime)
- CodeQL Java: `build-mode: manual` + `mvn compile` → `build-mode: none` (recommended for Maven without full build)

## Test plan
- [ ] CI `quality` job passes (Checkstyle, tests, Codecov)
- [ ] CI `codeql` job passes without overlay-database warning
- [ ] Annotations show 0 warnings (no Node.js 20 deprecation)


Made with [Cursor](https://cursor.com)